### PR TITLE
refactor: split src/memory.rs into modules

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use memory::MemoryStats;
-use memory::Processes;
+use process::Processes;
 
 mod memory;
+mod process;
+mod utils;
 
 type AnyError = Box<dyn std::error::Error + Send + Sync>;
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -7,6 +7,8 @@ use tokio::task;
 
 use std::io::{BufRead, BufReader};
 
+use crate::utils::{format_size, can_read_file, get_cmd, parse_value};
+
 #[derive(Default, Clone, Copy)]
 pub struct MemoryStats {
     pub total: u64,
@@ -217,122 +219,4 @@ impl ProcessMemoryStats {
             self.command
         );
     }
-}
-
-pub struct Process {
-    pid: u32,
-    command: String,
-    memory: ProcessMemoryStats,
-}
-
-impl Process {
-    pub fn new(pid: u32) -> Self {
-        let mut process = Self {
-            pid,
-            command: String::new(),
-            memory: ProcessMemoryStats::new(),
-        };
-        process.update().unwrap_or_else(|e| {
-            eprintln!("Error: {}", e);
-        });
-        process
-    }
-
-    pub fn update(&mut self) -> Result<(), AnyError> {
-        self.command = get_cmd(self.pid)?;
-        self.memory.update(&self.pid)?;
-        Ok(())
-    }
-}
-
-pub struct Processes {
-    processes: Vec<Process>,
-}
-
-impl Processes {
-    pub fn new() -> Self {
-        Self { processes: vec![] }
-    }
-
-    /// Update the processes
-    /// Uses a thread pool to get the memory stats for each process that has a command and can be read from /proc
-    ///
-    /// # Examples
-    /// ```
-    /// let mut processes = Processes::new();
-    /// processes.update()?;
-    /// ```
-    pub async fn update(&mut self) -> Result<(), AnyError> {
-        let processes = fs::read_dir("/proc")?
-            .filter_map(|entry| {
-                let entry = entry.ok()?;
-                // Try to parse the file name as a pid
-                let pid = entry.file_name().to_string_lossy().parse::<u32>().ok()?;
-                let command = get_cmd(pid).ok()?;
-                // Only add the process if it has a command and we can read the smaps
-                if command.is_empty() || !can_read_file(&format!("/proc/{}/smaps", pid)) {
-                    return None;
-                }
-                Some(task::spawn(async move { Process::new(pid) }))
-            })
-            .collect::<Vec<_>>();
-
-        // Wait for all the processes to finish
-        let mut processes = futures::future::try_join_all(processes).await?;
-        // Sort the processes by swap usage
-        processes.sort_by_key(|p| p.memory.swap);
-        self.processes = processes;
-        Ok(())
-    }
-
-    pub fn display(&self) {
-        println!(
-            "\n{:>10} {:>14} {:>14} {:>14} {:>14} {:>14}",
-            "PID".bold(),
-            "Swap".bold(),
-            "USS".bold(),
-            "PSS".bold(),
-            "RSS".bold(),
-            "COMMAND".bold()
-        );
-        for process in &self.processes {
-            process.memory.display();
-        }
-    }
-}
-
-fn format_size(size: u64) -> String {
-    let mut size = size as f64;
-    let mut unit = "kB";
-    if size > 1024.0 {
-        size /= 1024.0;
-        unit = "MB";
-    }
-    if size > 1024.0 {
-        size /= 1024.0;
-        unit = "GB";
-    }
-    if size > 1024.0 {
-        size /= 1024.0;
-        unit = "TB";
-    }
-
-    format!("{:.2} {}", size, unit)
-}
-
-fn can_read_file(path: &str) -> bool {
-    File::open(path).is_ok()
-}
-
-fn get_cmd(pid: u32) -> Result<String, AnyError> {
-    let mut file = File::open(format!("/proc/{}/cmdline", pid))?;
-    let mut contents = String::new();
-    file.read_to_string(&mut contents)?;
-    Ok(contents.replace('\0', " "))
-}
-
-fn parse_value(line: &str) -> Result<u64, AnyError> {
-    let value_str = line.split_ascii_whitespace().next().unwrap_or("0");
-    let value = u64::from_str_radix(value_str, 10)?;
-    Ok(value)
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,82 @@
+pub struct Process {
+    pid: u32,
+    command: String,
+    memory: ProcessMemoryStats,
+}
+
+impl Process {
+    pub fn new(pid: u32) -> Self {
+        let mut process = Self {
+            pid,
+            command: String::new(),
+            memory: ProcessMemoryStats::new(),
+        };
+        process.update().unwrap_or_else(|e| {
+            eprintln!("Error: {}", e);
+        });
+        process
+    }
+
+    pub fn update(&mut self) -> Result<(), AnyError> {
+        self.command = get_cmd(self.pid)?;
+        self.memory.update(&self.pid)?;
+        Ok(())
+    }
+}
+
+pub struct Processes {
+    processes: Vec<Process>,
+}
+
+impl Processes {
+    pub fn new() -> Self {
+        Self { processes: vec![] }
+    }
+
+    /// Update the processes
+    /// Uses a thread pool to get the memory stats for each process that has a command and can be read from /proc
+    ///
+    /// # Examples
+    /// ```
+    /// let mut processes = Processes::new();
+    /// processes.update()?;
+    /// ```
+    pub async fn update(&mut self) -> Result<(), AnyError> {
+        let processes = fs::read_dir("/proc")?
+            .filter_map(|entry| {
+                let entry = entry.ok()?;
+                // Try to parse the file name as a pid
+                let pid = entry.file_name().to_string_lossy().parse::<u32>().ok()?;
+                let command = get_cmd(pid).ok()?;
+                // Only add the process if it has a command and we can read the smaps
+                if command.is_empty() || !can_read_file(&format!("/proc/{}/smaps", pid)) {
+                    return None;
+                }
+                Some(task::spawn(async move { Process::new(pid) }))
+            })
+            .collect::<Vec<_>>();
+
+        // Wait for all the processes to finish
+        let mut processes = futures::future::try_join_all(processes).await?;
+        // Sort the processes by swap usage
+        processes.sort_by_key(|p| p.memory.swap);
+        self.processes = processes;
+        Ok(())
+    }
+
+    pub fn display(&self) {
+        println!(
+            "\n{:>10} {:>14} {:>14} {:>14} {:>14} {:>14}",
+            "PID".bold(),
+            "Swap".bold(),
+            "USS".bold(),
+            "PSS".bold(),
+            "RSS".bold(),
+            "COMMAND".bold()
+        );
+        for process in &self.processes {
+            process.memory.display();
+        }
+    }
+}
+

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,37 @@
+use std::fs::File;
+
+pub fn format_size(size: u64) -> String {
+    let mut size = size as f64;
+    let mut unit = "kB";
+    if size > 1024.0 {
+        size /= 1024.0;
+        unit = "MB";
+    }
+    if size > 1024.0 {
+        size /= 1024.0;
+        unit = "GB";
+    }
+    if size > 1024.0 {
+        size /= 1024.0;
+        unit = "TB";
+    }
+
+    format!("{:.2} {}", size, unit)
+}
+
+pub fn can_read_file(path: &str) -> bool {
+    File::open(path).is_ok()
+}
+
+pub fn get_cmd(pid: u32) -> Result<String, AnyError> {
+    let mut file = File::open(format!("/proc/{}/cmdline", pid))?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    Ok(contents.replace('\0', " "))
+}
+
+pub fn parse_value(line: &str) -> Result<u64, AnyError> {
+    let value_str = line.split_ascii_whitespace().next().unwrap_or("0");
+    let value = u64::from_str_radix(value_str, 10)?;
+    Ok(value)
+}


### PR DESCRIPTION
Split `src/memory.rs` into modules for easier organization.
Great program by the way!