### PR TITLE
fix(panic): use best-effort writing to stderr/stdout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
     if args.per_process {
         let mut processes = Processes::new();
         if let Err(e) = processes.update(args.sort_by) {
-            let _ = writeln!(io::stdout(), "error updating processes: {}", e);
+            let _ = writeln!(io::stderr(), "error updating processes: {}", e);
         }
 
         processes.display();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 
 use memory::MemoryStats;
 use process::{Processes, SortColumn};
+use std::io::{self, Write};
 
 mod memory;
 mod process;
@@ -28,14 +29,14 @@ fn main() {
 
     let mut mem = MemoryStats::new();
     if let Err(e) = mem.update() {
-        println!("error updating memory stats: {}", e);
+        let _ = writeln!(io::stderr(), "error updating memory stats: {}", e);
     }
     mem.display();
 
     if args.per_process {
         let mut processes = Processes::new();
         if let Err(e) = processes.update(args.sort_by) {
-            println!("error updating processes: {}", e);
+            let _ = writeln!(io::stdout(), "error updating processes: {}", e);
         }
 
         processes.display();

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,7 +1,7 @@
 use colored::{ColoredString, Colorize};
 use std::fs;
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{self, BufRead, BufReader, Write};
 
 use crate::utils::{format_size, parse_value};
 use crate::AnyError;
@@ -126,7 +126,8 @@ impl MemoryStats {
         }
 
         fn print_header() {
-            println!(
+            let _ = writeln!(
+                io::stdout(),
                 "{:>8} {} {} {} {} {} {}",
                 "",
                 fmt("total".to_string()).bold(),
@@ -151,7 +152,8 @@ impl MemoryStats {
             cached: u64,
             available: u64,
         ) {
-            println!(
+            let _ = writeln!(
+                io::stdout(),
                 "{:<8} {} {} {} {} {} {}",
                 name,
                 fmt(format_size(total)).green(),
@@ -196,10 +198,11 @@ impl MemoryStats {
             self.availablevmem,
         );
 
-        println!();
+        let _ = writeln!(io::stdout());
 
         fn print_zswap_header() {
-            println!(
+            let _ = writeln!(
+                io::stdout(),
                 "{:>8} {} {} {} {}",
                 "",
                 fmt("Stored".to_string()).bold(),
@@ -212,7 +215,8 @@ impl MemoryStats {
         print_zswap_header();
 
         fn print_z(name: &str, stored: u64, compressed: u64, ratio: f64, on_disk: Option<u64>) {
-            println!(
+            let _ = writeln!(
+                io::stdout(),
                 "{:<8} {} {} {} {}",
                 name.magenta().bold(),
                 fmt(format_size(stored)).green(),
@@ -234,7 +238,7 @@ impl MemoryStats {
             print_z("Zram:", zram.stored, zram.compressed, zram.ratio, None);
         }
 
-        println!();
+        let _ = writeln!(io::stdout());
     }
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,6 +1,7 @@
 use clap::ValueEnum;
 use colored::Colorize;
 use std::fs;
+use std::io::{self, Write};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 
@@ -56,14 +57,15 @@ impl Process {
     pub fn display(&self) {
         let fmt = |s: String| format!("{:>14}", s);
 
-        println!(
+        let _ = writeln!(
+            io::stdout(),
             "{:>10} {} {} {} {} {}",
             self.pid,
             fmt(format_size(self.memory.swap)).red(),
             fmt(format_size(self.memory.uss)).green(),
             fmt(format_size(self.memory.pss)).blue(),
             fmt(format_size(self.memory.rss)).cyan(),
-            self.command
+            self.command,
         );
     }
 }
@@ -128,14 +130,15 @@ impl Processes {
     }
 
     pub fn display(&self) {
-        println!(
+        let _ = writeln!(
+            io::stdout(),
             "\n{:>10} {:>14} {:>14} {:>14} {:>14} {:>14}",
             "PID".bold(),
             "Swap".bold(),
             "USS".bold(),
             "PSS".bold(),
             "RSS".bold(),
-            "COMMAND".bold()
+            "COMMAND".bold(),
         );
         for process in &self.processes {
             process.display();


### PR DESCRIPTION
Fixes a bug where piping to a command that doesn't consume its stdin would make `zmem` panic.
This makes the printing best-effort by using the `writeln!` macro and ignoring the result.

Fixes #149 